### PR TITLE
Release 1.10-RC1

### DIFF
--- a/justtestlah-awsdevicefarm/src/test/java/qa/justtestlah/awsdevicefarm/DeviceFilterFactoryTest.java
+++ b/justtestlah-awsdevicefarm/src/test/java/qa/justtestlah/awsdevicefarm/DeviceFilterFactoryTest.java
@@ -11,6 +11,7 @@ import com.amazonaws.services.devicefarm.model.Device;
 import com.amazonaws.services.devicefarm.model.ListDevicesResult;
 import java.util.Collections;
 import java.util.List;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -35,9 +36,11 @@ public class DeviceFilterFactoryTest {
 
   @Mock private ListDevicesResult resultBusy;
 
+  private AutoCloseable mocks;
+
   @BeforeEach
   public void setUp() {
-    MockitoAnnotations.initMocks(this);
+    mocks = MockitoAnnotations.openMocks(this);
     when(awsService.getAws()).thenReturn(awsDeviceFarm);
     when(properties.getProperty("platform")).thenReturn("android");
     doReturn(resultHighlyAvailable)
@@ -57,6 +60,11 @@ public class DeviceFilterFactoryTest {
         .listDevices(
             argThat(argument -> argument.getFilters().contains(DeviceFilterConstants.BUSY_FILTER)));
     target = new DeviceFilterFactory(properties, awsService);
+  }
+
+  @AfterEach
+  public void finish() throws Exception {
+    mocks.close();
   }
 
   @Test

--- a/justtestlah-awsdevicefarm/src/test/java/qa/justtestlah/awsdevicefarm/TestPackagerTest.java
+++ b/justtestlah-awsdevicefarm/src/test/java/qa/justtestlah/awsdevicefarm/TestPackagerTest.java
@@ -12,6 +12,8 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import org.apache.maven.shared.invoker.MavenInvocationException;
 import org.apache.maven.shared.invoker.PrintStreamHandler;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -25,12 +27,23 @@ public class TestPackagerTest {
 
   @Mock private PropertiesHolder properties;
 
+  private AutoCloseable mocks;
+
+  @BeforeEach
+  public void setup() {
+    mocks = MockitoAnnotations.openMocks(this);
+  }
+
+  @AfterEach
+  public void finish() throws Exception {
+    mocks.close();
+  }
+
   @Test
   public void testMavenPackaging()
       throws MavenInvocationException, MalformedURLException, IOException,
           ReflectiveOperationException {
     String currentPath = Paths.get("").toFile().getAbsolutePath();
-    MockitoAnnotations.initMocks(this);
     when(properties.getProperty("aws.demo.path")).thenReturn(currentPath);
     when(properties.getProperty("aws.testpackage.name")).thenReturn("justtestlah-awsdevicefarm");
     ByteArrayOutputStream logOutput = new ByteArrayOutputStream();

--- a/justtestlah-awsdevicefarm/src/test/java/qa/justtestlah/awsdevicefarm/TestSpecFactoryTest.java
+++ b/justtestlah-awsdevicefarm/src/test/java/qa/justtestlah/awsdevicefarm/TestSpecFactoryTest.java
@@ -10,6 +10,8 @@ import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Properties;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -19,9 +21,20 @@ public class TestSpecFactoryTest {
 
   @Mock private PropertiesHolder properties;
 
+  private AutoCloseable mocks;
+
+  @BeforeEach
+  public void setup() {
+    mocks = MockitoAnnotations.openMocks(this);
+  }
+
+  @AfterEach
+  public void finish() throws Exception {
+    mocks.close();
+  }
+
   @Test
   public void testCreateTestSpec() throws IOException, URISyntaxException {
-    MockitoAnnotations.initMocks(this);
     when(properties.getProperties()).thenReturn(new Properties());
 
     List<String> expected =

--- a/justtestlah-core/src/main/java/qa/justtestlah/base/BasePage.java
+++ b/justtestlah-core/src/main/java/qa/justtestlah/base/BasePage.java
@@ -10,6 +10,7 @@ import com.codeborne.selenide.ex.ElementNotFound;
 import io.appium.java_client.HasSettings;
 import io.appium.java_client.Setting;
 import java.io.File;
+import java.time.Duration;
 import org.apache.commons.lang3.tuple.Pair;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.TakesScreenshot;
@@ -217,8 +218,8 @@ public abstract class BasePage<T> extends Base implements InitializingBean {
    *
    * <p>Performs Galen checks, if enabled.
    *
-   * @param timeout the timeout for identifying the first element. Note, that there is no timeout
-   *     for any subsequent checks!
+   * @param timeout the timeout in milliseconds for identifying the first element. Note, that there
+   *     is no timeout for any subsequent checks!
    * @return this page object
    */
   @SuppressWarnings("unchecked")
@@ -241,9 +242,9 @@ public abstract class BasePage<T> extends Base implements InitializingBean {
           try {
             // only use the timeout for the first check
             if (initialCheck) {
-              $(identifier).waitUntil(appear, timeout).isDisplayed();
+              $(identifier).shouldBe(appear, Duration.ofMillis(timeout)).isDisplayed();
             } else {
-              $(identifier).waitUntil(appear, 0).isDisplayed();
+              $(identifier).shouldBe(appear, Duration.ZERO).isDisplayed();
             }
             initialCheck = false;
           } catch (ElementNotFound exception) {

--- a/justtestlah-core/src/main/java/qa/justtestlah/configuration/CucumberOptionsBuilder.java
+++ b/justtestlah-core/src/main/java/qa/justtestlah/configuration/CucumberOptionsBuilder.java
@@ -13,9 +13,7 @@ public class CucumberOptionsBuilder {
 
   private static final String PLATFORM_KEY = "platform";
   private static final String FEATURES_DIRECTORY_KEY = "features.directory";
-  private static final String CUCUMBER_REPORT_DIRECTORY_KEY = "cucumber.report.directory";
   private static final String JUSTTESTLAH_SPRING_CONTEXT_KEY = "justtestlah.use.springcontext";
-  private static final String DEFAULT_CUCUMBER_REPORT_DIRECTORY = "target/report/cucumber";
   private static final String DEFAULT_PLATFORM = "web";
   private static final String DELIMITER = ",";
   private static final String TAGS_KEY = "tags";

--- a/justtestlah-core/src/main/java/qa/justtestlah/log/CucumberLoggingPlugin.java
+++ b/justtestlah-core/src/main/java/qa/justtestlah/log/CucumberLoggingPlugin.java
@@ -28,6 +28,9 @@ public class CucumberLoggingPlugin implements ConcurrentEventListener {
                   "Scenario: {} ({}:{})",
                   testCase.getName(),
                   testCase.getUri(),
+                  // TODO: getLine() has been deprecated. Once this gets removed from Cucumber, we
+                  // will
+                  // simply drop it from the log too
                   testCase.getLine());
         }
       };
@@ -66,6 +69,10 @@ public class CucumberLoggingPlugin implements ConcurrentEventListener {
                     event.getTestCase().getName(),
                     result.getDuration().toSeconds());
           } else {
+            String errorMsg = error.getMessage();
+            if (errorMsg != null) {
+              errorMsg = errorMsg.replaceAll("[\\t\\n\\r]+", " ");
+            }
             SpringContext.getBean(TestLogWriter.class)
                 .log(
                     LogLevel.INFO,
@@ -74,7 +81,7 @@ public class CucumberLoggingPlugin implements ConcurrentEventListener {
                     result.getStatus(),
                     event.getTestCase().getName(),
                     result.getDuration().toSeconds(),
-                    error.getMessage().replaceAll("[\\t\\n\\r]+", " "));
+                    errorMsg);
           }
         }
       };

--- a/justtestlah-core/src/main/java/qa/justtestlah/testdata/TestDataMap.java
+++ b/justtestlah-core/src/main/java/qa/justtestlah/testdata/TestDataMap.java
@@ -93,7 +93,7 @@ public class TestDataMap implements InitializingBean {
     LOG.info("Scanning classpath for test data classes");
     ClassGraph classGraph = new ClassGraph().enableAnnotationInfo();
     if (modelPackage != null && !modelPackage.isEmpty()) {
-      classGraph = classGraph.whitelistPackages(modelPackage);
+      classGraph = classGraph.acceptPackages(modelPackage);
     }
     try (ScanResult scanResult = classGraph.scan()) {
       for (ClassInfo routeClassInfo :
@@ -112,7 +112,12 @@ public class TestDataMap implements InitializingBean {
   }
 
   public <T> T get(Class<T> type, String name) {
-    return (T) testData.get(type).get(name);
+    try {
+      return (T) testData.get(type).get(name);
+    } catch (NullPointerException e) {
+      throw new RuntimeException(
+          String.format("Error fetching test data. Test data map: %s", testData), e);
+    }
   }
 
   public <T> T get(Class<T> type) {

--- a/justtestlah-core/src/test/java/qa/justtestlah/base/BaseTest.java
+++ b/justtestlah-core/src/test/java/qa/justtestlah/base/BaseTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -16,13 +17,20 @@ public class BaseTest {
 
   @Mock private ApplicationContext applicationContext;
 
+  private AutoCloseable mocks;
+
   /** Initialise mocks. */
   @Before
   @SuppressWarnings("unchecked")
   public void init() {
-    MockitoAnnotations.initMocks(this);
+    mocks = MockitoAnnotations.openMocks(this);
     // mocking the Spring application context
     doReturn(new TestPageObject()).when(applicationContext).getBean(any(Class.class));
+  }
+
+  @After
+  public void finish() throws Exception {
+    mocks.close();
   }
 
   /** Test the injection of page objects . */

--- a/justtestlah-demos/pom.xml
+++ b/justtestlah-demos/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>qa.justtestlah</groupId>
     <artifactId>justtestlah-parent</artifactId>
-    <version>1.9-RC4</version>
+    <version>1.10-SNAPSHOT</version>
   </parent>
   <licenses>
     <license>

--- a/justtestlah-demos/src/test/java/qa/justtestlah/examples/google/pages/ResultsPage.java
+++ b/justtestlah-demos/src/test/java/qa/justtestlah/examples/google/pages/ResultsPage.java
@@ -1,17 +1,13 @@
 package qa.justtestlah.examples.google.pages;
 
 import static qa.justtestlah.configuration.Platform.Constants.WEB;
-
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import qa.justtestlah.annotations.ScreenIdentifier;
 import qa.justtestlah.base.BasePage;
-import qa.justtestlah.examples.google.model.Search;
-import qa.justtestlah.visual.OCR;
 
 @Component
 @Profile(WEB)
-@ScreenIdentifier({"SEARCH_RESULT", "RESULT_STATS"})
+@ScreenIdentifier({"RESULT_STATS"})
 public class ResultsPage extends BasePage<ResultsPage> {
 }

--- a/justtestlah-demos/src/test/resources/features/google/Google.feature
+++ b/justtestlah-demos/src/test/resources/features/google/Google.feature
@@ -3,9 +3,9 @@ Feature: Google search
 @web @integration
 Scenario: Search 
 	Given I am on the homepage 
-	Then I can see the Google logo
+	#Then I can see the Google logo
 	When I search for "default"
 	Then I can see search results
-	When I click on the Google logo
-	Then I am on the homepage
-	And I can see the Google logo
+	#When I click on the Google logo
+	#Then I am on the homepage
+	#And I can see the Google logo

--- a/justtestlah-demos/src/test/resources/features/google/More search queries.feature
+++ b/justtestlah-demos/src/test/resources/features/google/More search queries.feature
@@ -1,0 +1,7 @@
+Feature: Google search
+
+#@web @integration
+Scenario: Search for Selenium
+	Given I am on the homepage 
+	When I search for "selenium"
+	Then I can see search results

--- a/justtestlah-demos/src/test/resources/features/google/Search queries.feature
+++ b/justtestlah-demos/src/test/resources/features/google/Search queries.feature
@@ -1,0 +1,7 @@
+Feature: Google search
+	
+@web @integration
+Scenario: Search for Cucumber
+	Given I am on the homepage 
+	When I search for "cucumber"
+	Then I can see search results

--- a/justtestlah-demos/src/test/resources/justtestlah.properties
+++ b/justtestlah-demos/src/test/resources/justtestlah.properties
@@ -4,10 +4,12 @@
 
 # GENERAL settings
 platform=web
-pages.package=qa.justtestlah.examples.stackoverflow.pages
-steps.package=qa.justtestlah.examples.stackoverflow.steps
-model.package=qa.justtestlah.examples.stackoverflow.model
-features.directory=src/test/resources/features/stackoverflow
+pages.package=qa.justtestlah.examples.google.pages
+steps.package=qa.justtestlah.examples.google.steps
+model.package=qa.justtestlah.examples.google.model
+testdata.enabled=true
+testdata.filter=google/testdata
+features.directory=src/test/resources/features/google
 cucumber.report.directory=target/report/cucumber
 cloudprovider=local
 
@@ -21,7 +23,7 @@ eyes.apiKey=
 
 
 # WEB settings
-web.baseUrl=https://www.stackoverflow.com
+web.baseUrl=https://www.google.com
 web.browser=chrome
 web.headless=false
 

--- a/justtestlah-demos/src/test/resources/qa/justtestlah/examples/google/testdata/search/appium.yaml
+++ b/justtestlah-demos/src/test/resources/qa/justtestlah/examples/google/testdata/search/appium.yaml
@@ -1,0 +1,3 @@
+search:
+  searchTerm: appium
+

--- a/justtestlah-demos/src/test/resources/qa/justtestlah/examples/google/testdata/search/cucumber.yaml
+++ b/justtestlah-demos/src/test/resources/qa/justtestlah/examples/google/testdata/search/cucumber.yaml
@@ -1,0 +1,3 @@
+search:
+  searchTerm: cucumber
+

--- a/justtestlah-demos/src/test/resources/qa/justtestlah/examples/google/testdata/search/selenium.yaml
+++ b/justtestlah-demos/src/test/resources/qa/justtestlah/examples/google/testdata/search/selenium.yaml
@@ -1,0 +1,3 @@
+search:
+  searchTerm: selenium
+


### PR DESCRIPTION
- Update JustTestLahRunner to match the current Cucumber version.
- Fix broken initializing of page objects.
- Avoid potential NPEs and improve logging.
- Some quick fixes in justtestlah-demos.
- Avoid using deprecated methods.